### PR TITLE
Updating version number in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simply define the following `<parent>` in your `pom.xml`:
 <parent>
   <groupId>org.finos</groupId>
   <artifactId>finos</artifactId>
-  <version>1</version>
+  <version>4</version>
 </parent>
 ```
 


### PR DESCRIPTION
The currently listed version number (1) does not seem to exist in maven central.  Updating to 4 as it seems to be the latest.