### PR TITLE
Remove elements repositories and distributionManagement from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,17 +75,6 @@ under the License.
     </pluginRepository>
   </pluginRepositories>
 
-  <repositories>
-    <repository>
-      <id>ossrh</id>
-      <name>OSSRH Public Group</name>
-      <url>https://${repoServerHost}/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <distributionManagement>
     <repository>
       <id>ossrh-distro</id>


### PR DESCRIPTION
Remove elements `<repositories>` and `<distributionManagement>`.

By default Maven searches the central repository at https://repo.maven.apache.org/maven2/. Additional repositories can be configured in the pom.xml `repositories` element.

We deploy to https://oss.sonatype.org/ but the artifacts are published to Maven Central https://mvnrepository.com/artifact/org.finos/finos

We should not guide users to download our artifacts from Sonatype when they are available at Maven Central where Maven by default looks for them.

If user needs to access them from Sonatype, e.g. to access the snapshots, user can configure a mirror in user specific `~/.m2/settings.xml` file.