### PR TITLE
Make executions unique for maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@ under the License.
             <artifactId>maven-source-plugin</artifactId>
             <executions>
               <execution>
-                <id>attach-sources</id>
+                <id>release-attach-sources</id>
                 <goals>
                   <goal>jar-no-fork</goal>
                 </goals>


### PR DESCRIPTION
maven-source-plugin has two executions called attach-sources in profiles release and attach-sources.