### PR TITLE
Remove needless execution of maven-source-plugin from pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,13 +270,6 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.3.1</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We use release profile to create these.
It has another maven-source-plugin execution.